### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: sandersaares/consumer
         username: sandersaares


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore